### PR TITLE
Adopt version core naming

### DIFF
--- a/src/DashDashVersion/DashDashVersion.csproj
+++ b/src/DashDashVersion/DashDashVersion.csproj
@@ -24,7 +24,7 @@ along with DashDashVersion. If not, see<https://www.gnu.org/licenses/>.
     <Description>This libary can generate a version numbers for a git flow repository.</Description>
     <IsPackable>true</IsPackable>
     <LangVersion>8.0</LangVersion>
-    <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.26.0" />

--- a/src/DashDashVersion/Patterns.cs
+++ b/src/DashDashVersion/Patterns.cs
@@ -24,7 +24,7 @@ namespace DashDashVersion
     /// </summary>
     internal class Patterns
     {
-        internal static Regex IsVersionCoreTag = new Regex(@"^(?<BaseVersion>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+))$", RegexOptions.Compiled);
+        internal static Regex IsCoreVersionTag = new Regex(@"^(?<BaseVersion>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+))$", RegexOptions.Compiled);
 
         internal static Regex ContainsVersionNumber = new Regex(@"(?<BaseVersion>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+))", RegexOptions.Compiled);
 

--- a/src/DashDashVersion/Patterns.cs
+++ b/src/DashDashVersion/Patterns.cs
@@ -24,7 +24,7 @@ namespace DashDashVersion
     /// </summary>
     internal class Patterns
     {
-        internal static Regex IsReleaseVersionTag = new Regex(@"^(?<BaseVersion>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+))$", RegexOptions.Compiled);
+        internal static Regex IsVersionCoreTag = new Regex(@"^(?<BaseVersion>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+))$", RegexOptions.Compiled);
 
         internal static Regex ContainsVersionNumber = new Regex(@"(?<BaseVersion>(?<Major>\d+)\.(?<Minor>\d+)\.(?<Patch>\d+))", RegexOptions.Compiled);
 

--- a/src/DashDashVersion/RepositoryAbstraction/IGitRepoReader.cs
+++ b/src/DashDashVersion/RepositoryAbstraction/IGitRepoReader.cs
@@ -26,13 +26,13 @@ namespace DashDashVersion.RepositoryAbstraction
 
         string HeadCommitHash { get; }
 
-        VersionNumber CurrentReleaseVersion { get; }
+        VersionNumber CurrentVersionCore { get; }
         
         GitTag TagOnHead { get; }
 
         VersionNumber? HighestMatchingTagForReleaseCandidate { get; }
 
-        uint CommitCountSinceLastMinorReleaseVersion { get; }
+        uint CommitCountSinceLastMinorVersion { get; }
 
         uint CommitCountSinceBranchOffFromDevelop { get; }
     }

--- a/src/DashDashVersion/RepositoryAbstraction/IGitRepoReader.cs
+++ b/src/DashDashVersion/RepositoryAbstraction/IGitRepoReader.cs
@@ -26,7 +26,7 @@ namespace DashDashVersion.RepositoryAbstraction
 
         string HeadCommitHash { get; }
 
-        VersionNumber CurrentVersionCore { get; }
+        VersionNumber CurrentCoreVersion { get; }
         
         GitTag TagOnHead { get; }
 

--- a/src/DashDashVersion/VersionNumberGenerator.cs
+++ b/src/DashDashVersion/VersionNumberGenerator.cs
@@ -63,10 +63,10 @@ namespace DashDashVersion
             DevelopBranchInfo develop,
             string headCommitHash) =>
             new VersionNumber(
-                repo.CurrentReleaseVersion.Major, 
-                repo.CurrentReleaseVersion.Minor + 1,
+                repo.CurrentVersionCore.Major, 
+                repo.CurrentVersionCore.Minor + 1,
                 0,
-                develop.DeterminePreReleaseLabel(repo.CommitCountSinceLastMinorReleaseVersion),
+                develop.DeterminePreReleaseLabel(repo.CommitCountSinceLastMinorVersion),
                 headCommitHash);
 
         private static VersionNumber GenerateReleaseVersionNumber(
@@ -92,11 +92,11 @@ namespace DashDashVersion
             string headCommitHash)
         {
             var preReleaseLabel = feature.DeterminePreReleaseLabel(
-                repo.CommitCountSinceLastMinorReleaseVersion - repo.CommitCountSinceBranchOffFromDevelop,
+                repo.CommitCountSinceLastMinorVersion - repo.CommitCountSinceBranchOffFromDevelop,
                 repo.CommitCountSinceBranchOffFromDevelop);
             return new VersionNumber(
-                repo.CurrentReleaseVersion.Major, 
-                repo.CurrentReleaseVersion.Minor + 1,
+                repo.CurrentVersionCore.Major, 
+                repo.CurrentVersionCore.Minor + 1,
                 0,
                 preReleaseLabel,
                 headCommitHash);
@@ -104,6 +104,6 @@ namespace DashDashVersion
 
         private static bool TagOnHeadIsMajorMinorPatch(GitTag tagOnHead) => 
             tagOnHead != null && 
-            Patterns.IsReleaseVersionTag.IsMatch(tagOnHead.FriendlyName);
+            Patterns.IsVersionCoreTag.IsMatch(tagOnHead.FriendlyName);
     }
 }

--- a/src/DashDashVersion/VersionNumberGenerator.cs
+++ b/src/DashDashVersion/VersionNumberGenerator.cs
@@ -63,8 +63,8 @@ namespace DashDashVersion
             DevelopBranchInfo develop,
             string headCommitHash) =>
             new VersionNumber(
-                repo.CurrentVersionCore.Major, 
-                repo.CurrentVersionCore.Minor + 1,
+                repo.CurrentCoreVersion.Major, 
+                repo.CurrentCoreVersion.Minor + 1,
                 0,
                 develop.DeterminePreReleaseLabel(repo.CommitCountSinceLastMinorVersion),
                 headCommitHash);
@@ -95,8 +95,8 @@ namespace DashDashVersion
                 repo.CommitCountSinceLastMinorVersion - repo.CommitCountSinceBranchOffFromDevelop,
                 repo.CommitCountSinceBranchOffFromDevelop);
             return new VersionNumber(
-                repo.CurrentVersionCore.Major, 
-                repo.CurrentVersionCore.Minor + 1,
+                repo.CurrentCoreVersion.Major, 
+                repo.CurrentCoreVersion.Minor + 1,
                 0,
                 preReleaseLabel,
                 headCommitHash);
@@ -104,6 +104,6 @@ namespace DashDashVersion
 
         private static bool TagOnHeadIsMajorMinorPatch(GitTag tagOnHead) => 
             tagOnHead != null && 
-            Patterns.IsVersionCoreTag.IsMatch(tagOnHead.FriendlyName);
+            Patterns.IsCoreVersionTag.IsMatch(tagOnHead.FriendlyName);
     }
 }

--- a/src/git-flow-version/git-flow-version.csproj
+++ b/src/git-flow-version/git-flow-version.csproj
@@ -27,6 +27,7 @@ along with DashDashVersion. If not, see<https://www.gnu.org/licenses/>.
     <PackAsTool>true</PackAsTool>
     <LangVersion>8.0</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <NullableReferenceTypes>true</NullableReferenceTypes>
   </PropertyGroup>
     
   <ItemGroup>

--- a/test/DashDashVersionTests/GenerateVersionTests.cs
+++ b/test/DashDashVersionTests/GenerateVersionTests.cs
@@ -53,7 +53,7 @@ namespace DashDashVersionTests
             string expectedVersion)
         {
             _mock.Setup(f => f.CurrentBranch).Returns(BranchInfoFactory.CreateBranchInfo(Constants.DevelopBranchName));
-            _mock.Setup(f => f.CurrentVersionCore).Returns(VersionNumber.Parse(highestAnnotatedTag));
+            _mock.Setup(f => f.CurrentCoreVersion).Returns(VersionNumber.Parse(highestAnnotatedTag));
             _mock.Setup(f => f.CommitCountSinceLastMinorVersion).Returns(commitsSinceAnnotatedTag);
             _mock.Setup(f => f.HeadCommitHash).Returns(hash);
 
@@ -75,7 +75,7 @@ namespace DashDashVersionTests
             string expectedVersion)
         {
             _mock.Setup(f => f.CurrentBranch).Returns(BranchInfoFactory.CreateBranchInfo(branchName));
-            _mock.Setup(f => f.CurrentVersionCore).Returns(VersionNumber.Parse(highestAnnotatedTag));
+            _mock.Setup(f => f.CurrentCoreVersion).Returns(VersionNumber.Parse(highestAnnotatedTag));
             _mock.Setup(f => f.CommitCountSinceLastMinorVersion).Returns(commitsSinceAnnotatedTag);
             _mock.Setup(f => f.CommitCountSinceBranchOffFromDevelop).Returns(commitsSinceBranchOff);
             _mock.Setup(f => f.HeadCommitHash).Returns(hash);

--- a/test/DashDashVersionTests/GenerateVersionTests.cs
+++ b/test/DashDashVersionTests/GenerateVersionTests.cs
@@ -53,8 +53,8 @@ namespace DashDashVersionTests
             string expectedVersion)
         {
             _mock.Setup(f => f.CurrentBranch).Returns(BranchInfoFactory.CreateBranchInfo(Constants.DevelopBranchName));
-            _mock.Setup(f => f.CurrentReleaseVersion).Returns(VersionNumber.Parse(highestAnnotatedTag));
-            _mock.Setup(f => f.CommitCountSinceLastMinorReleaseVersion).Returns(commitsSinceAnnotatedTag);
+            _mock.Setup(f => f.CurrentVersionCore).Returns(VersionNumber.Parse(highestAnnotatedTag));
+            _mock.Setup(f => f.CommitCountSinceLastMinorVersion).Returns(commitsSinceAnnotatedTag);
             _mock.Setup(f => f.HeadCommitHash).Returns(hash);
 
             var version = VersionNumberGenerator.GenerateVersionNumber(_mock.Object);
@@ -75,8 +75,8 @@ namespace DashDashVersionTests
             string expectedVersion)
         {
             _mock.Setup(f => f.CurrentBranch).Returns(BranchInfoFactory.CreateBranchInfo(branchName));
-            _mock.Setup(f => f.CurrentReleaseVersion).Returns(VersionNumber.Parse(highestAnnotatedTag));
-            _mock.Setup(f => f.CommitCountSinceLastMinorReleaseVersion).Returns(commitsSinceAnnotatedTag);
+            _mock.Setup(f => f.CurrentVersionCore).Returns(VersionNumber.Parse(highestAnnotatedTag));
+            _mock.Setup(f => f.CommitCountSinceLastMinorVersion).Returns(commitsSinceAnnotatedTag);
             _mock.Setup(f => f.CommitCountSinceBranchOffFromDevelop).Returns(commitsSinceBranchOff);
             _mock.Setup(f => f.HeadCommitHash).Returns(hash);
 

--- a/test/DashDashVersionTests/GitRepoReaderTests.cs
+++ b/test/DashDashVersionTests/GitRepoReaderTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Hightech ICT and authors
+﻿// Copyright 2019 Hightech ICT and authors
 
 // This file is part of DashDashVersion.
 
@@ -30,9 +30,9 @@ namespace DashDashVersionTests
         {
             var repoReader = new GitRepoReader(TestRepositories.MasterOnlyRepository(), string.Empty);
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.MasterBranchName);
-            repoReader.CommitCountSinceLastMinorReleaseVersion.Should().Be(0);
+            repoReader.CommitCountSinceLastMinorVersion.Should().Be(0);
             repoReader.HeadCommitHash.Should().Be("a");
-            repoReader.CurrentReleaseVersion.SemVer.Should().Be("1.0.0");
+            repoReader.CurrentVersionCore.SemVer.Should().Be("1.0.0");
         }
 
         [Fact]
@@ -40,9 +40,9 @@ namespace DashDashVersionTests
         {
             var repoReader = new GitRepoReader(TestRepositories.MasterAheadOfDevelopRepository(), string.Empty);
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.DevelopBranchName);
-            repoReader.CommitCountSinceLastMinorReleaseVersion.Should().Be(1);
+            repoReader.CommitCountSinceLastMinorVersion.Should().Be(1);
             repoReader.HeadCommitHash.Should().Be("b");
-            repoReader.CurrentReleaseVersion.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
         }
 
         [Fact]
@@ -50,9 +50,9 @@ namespace DashDashVersionTests
         {
             var repoReader = new GitRepoReader(TestRepositories.TwoCommitsOnDevelopRepository(), string.Empty);
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(0);
-            repoReader.CommitCountSinceLastMinorReleaseVersion.Should().Be(1);
+            repoReader.CommitCountSinceLastMinorVersion.Should().Be(1);
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.DevelopBranchName);
-            repoReader.CurrentReleaseVersion.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
             repoReader.HeadCommitHash.Should().Be("b");
         }
 
@@ -61,9 +61,9 @@ namespace DashDashVersionTests
         {
             var repoReader = new GitRepoReader(TestRepositories.RemoteDevelopRepository(), string.Empty);
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(0);
-            repoReader.CommitCountSinceLastMinorReleaseVersion.Should().Be(1);
+            repoReader.CommitCountSinceLastMinorVersion.Should().Be(1);
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.DevelopBranchName);
-            repoReader.CurrentReleaseVersion.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
             repoReader.HeadCommitHash.Should().Be("b");
         }
 
@@ -72,9 +72,9 @@ namespace DashDashVersionTests
         {
             var repoReader = new GitRepoReader(TestRepositories.ReleaseBranchRepositoryWithoutTag(), string.Empty);
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(1);
-            repoReader.CommitCountSinceLastMinorReleaseVersion.Should().Be(2);
+            repoReader.CommitCountSinceLastMinorVersion.Should().Be(2);
             repoReader.HeadCommitHash.Should().Be("c");
-            repoReader.CurrentReleaseVersion.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
             repoReader.CurrentBranch.Name.Should().Be($"{DashDashVersion.Constants.ReleaseBranchName}/1.0.0");
             repoReader.HighestMatchingTagForReleaseCandidate.Should().BeNull();
         }
@@ -84,9 +84,9 @@ namespace DashDashVersionTests
         {
             var repoReader = new GitRepoReader(TestRepositories.ReleaseBranchRepositoryWithTaggedRc(), string.Empty);
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(3);
-            repoReader.CommitCountSinceLastMinorReleaseVersion.Should().Be(4);
+            repoReader.CommitCountSinceLastMinorVersion.Should().Be(4);
             repoReader.HeadCommitHash.Should().Be("e");
-            repoReader.CurrentReleaseVersion.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
             repoReader.CurrentBranch.Name.Should().Be($"{DashDashVersion.Constants.ReleaseBranchName}/1.0.0");
             repoReader.HighestMatchingTagForReleaseCandidate?.ToString().Should().Be("1.0.0-rc.2");
         }
@@ -96,9 +96,9 @@ namespace DashDashVersionTests
         {
             var repoReader = new GitRepoReader(TestRepositories.FeatureBranchOnFeatureBranchRepository(), string.Empty);
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(2);
-            repoReader.CommitCountSinceLastMinorReleaseVersion.Should().Be(3);
+            repoReader.CommitCountSinceLastMinorVersion.Should().Be(3);
             repoReader.HeadCommitHash.Should().Be("d");
-            repoReader.CurrentReleaseVersion.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
             repoReader.CurrentBranch.Name.Should().Be($"{DashDashVersion.Constants.FeatureBranchName}/B");
         }
     }

--- a/test/DashDashVersionTests/GitRepoReaderTests.cs
+++ b/test/DashDashVersionTests/GitRepoReaderTests.cs
@@ -32,7 +32,7 @@ namespace DashDashVersionTests
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.MasterBranchName);
             repoReader.CommitCountSinceLastMinorVersion.Should().Be(0);
             repoReader.HeadCommitHash.Should().Be("a");
-            repoReader.CurrentVersionCore.SemVer.Should().Be("1.0.0");
+            repoReader.CurrentCoreVersion.SemVer.Should().Be("1.0.0");
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace DashDashVersionTests
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.DevelopBranchName);
             repoReader.CommitCountSinceLastMinorVersion.Should().Be(1);
             repoReader.HeadCommitHash.Should().Be("b");
-            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentCoreVersion.SemVer.Should().Be("0.0.0");
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DashDashVersionTests
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(0);
             repoReader.CommitCountSinceLastMinorVersion.Should().Be(1);
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.DevelopBranchName);
-            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentCoreVersion.SemVer.Should().Be("0.0.0");
             repoReader.HeadCommitHash.Should().Be("b");
         }
 
@@ -63,7 +63,7 @@ namespace DashDashVersionTests
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(0);
             repoReader.CommitCountSinceLastMinorVersion.Should().Be(1);
             repoReader.CurrentBranch.Name.Should().Be(DashDashVersion.Constants.DevelopBranchName);
-            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentCoreVersion.SemVer.Should().Be("0.0.0");
             repoReader.HeadCommitHash.Should().Be("b");
         }
 
@@ -74,7 +74,7 @@ namespace DashDashVersionTests
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(1);
             repoReader.CommitCountSinceLastMinorVersion.Should().Be(2);
             repoReader.HeadCommitHash.Should().Be("c");
-            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentCoreVersion.SemVer.Should().Be("0.0.0");
             repoReader.CurrentBranch.Name.Should().Be($"{DashDashVersion.Constants.ReleaseBranchName}/1.0.0");
             repoReader.HighestMatchingTagForReleaseCandidate.Should().BeNull();
         }
@@ -86,7 +86,7 @@ namespace DashDashVersionTests
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(3);
             repoReader.CommitCountSinceLastMinorVersion.Should().Be(4);
             repoReader.HeadCommitHash.Should().Be("e");
-            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentCoreVersion.SemVer.Should().Be("0.0.0");
             repoReader.CurrentBranch.Name.Should().Be($"{DashDashVersion.Constants.ReleaseBranchName}/1.0.0");
             repoReader.HighestMatchingTagForReleaseCandidate?.ToString().Should().Be("1.0.0-rc.2");
         }
@@ -98,7 +98,7 @@ namespace DashDashVersionTests
             repoReader.CommitCountSinceBranchOffFromDevelop.Should().Be(2);
             repoReader.CommitCountSinceLastMinorVersion.Should().Be(3);
             repoReader.HeadCommitHash.Should().Be("d");
-            repoReader.CurrentVersionCore.SemVer.Should().Be("0.0.0");
+            repoReader.CurrentCoreVersion.SemVer.Should().Be("0.0.0");
             repoReader.CurrentBranch.Name.Should().Be($"{DashDashVersion.Constants.FeatureBranchName}/B");
         }
     }


### PR DESCRIPTION
Since
https://github.com/semver/semver/blob/master/semver.md#backusnaur-form-grammar-for-valid-semver-versions
uses the term 'version core' for an unadorned <major>.<minor>.<patch>
format version this change tries to make the names in the code-base use
that definition.